### PR TITLE
[PPP-4182] Use of vulnerable component dom4j-1.6.1.jar  CVE-2018-1000632

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,28 +30,20 @@
   </licenses>
 
   <properties>
-    <dom4j.version>1.6.1</dom4j.version>
-    <jaxen.version>1.1</jaxen.version>
     <commons-logging.version>1.1.3</commons-logging.version>
     <pentaho-connections.version>8.2.0.0-SNAPSHOT</pentaho-connections.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
-      <version>${dom4j.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
+    <!-- required by org.dom4j -->
     <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
-      <version>${jaxen.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>


### PR DESCRIPTION
This is one of a series of PRs. See pentaho/maven-parent-poms#70 for the complete list and more details. **Do not merge until further notice!**

@graimundo